### PR TITLE
将 AddinManager 成功移植到 AutoCAD 2016 中并测试成功！

### DIFF
--- a/eZcad/Addins/CombineDbTexts.cs
+++ b/eZcad/Addins/CombineDbTexts.cs
@@ -1,0 +1,84 @@
+﻿using System.Linq;
+using System.Text;
+using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.EditorInput;
+using Autodesk.AutoCAD.Runtime;
+using eZcad.Addins;
+using eZcad.Utility;
+
+[assembly: CommandClass(typeof (CombineDbTexts))]
+
+namespace eZcad.Addins
+{
+    /// <summary> 将单行文字转换为多行文字 </summary>
+    public class CombineDbTexts
+    {
+        /// <summary> 将单行文字转换为多行文字 </summary>
+        [CommandMethod("eZcad", "CombineDbTexts", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        public void EcCombineDbTexts()
+        {
+            DocumentModifier.ExecuteCommand(Execute);
+        }
+
+        /// <summary> 将单行文字转换为多行文字 </summary>
+        public void Execute(DocumentModifier docMdf, SelectionSet impliedSelection)
+        {
+            var textIds = SelectDbtexts(docMdf);
+            if (textIds != null && textIds.Length > 0)
+            {
+                var texts = textIds.Select(r => r.GetObject(OpenMode.ForRead) as DBText);
+                var arr2D = new EntityArray2D<DBText>(texts);
+                var textsArr2D = arr2D.Arrange2D();
+                //
+                for (int r = 0; r < textsArr2D.GetLength(0); r++)
+                {
+                    // 将一行中的所有文字转换到一个单行文字中
+                    var sb = new StringBuilder();
+                    DBText baseText = null;
+                    for (int c = 0; c < textsArr2D.GetLength(1); c++)
+                    {
+                        var cellTexts = textsArr2D[r, c];
+                        if (cellTexts.Count > 0)
+                        {
+                            if (baseText == null)
+                            {
+                                baseText = cellTexts.First();
+                            }
+                            foreach (var t in cellTexts)
+                            {
+                                sb.Append(t.TextString);
+                                docMdf.WriteLineIntoDebuger(r, c, t.TextString);
+                            }
+                        }
+                        if (baseText != null)
+                        {
+                            baseText.UpgradeOpen();
+                            baseText.TextString = sb.ToString();
+                        }
+                    }
+                }
+            }
+        }
+
+        private ObjectId[] SelectDbtexts(DocumentModifier docMdf)
+        {
+            // Create our options object
+            var pso = new PromptSelectionOptions();
+
+            // Set our prompts to include our keywords
+            string kws = pso.Keywords.GetDisplayString(true);
+            pso.MessageForAdding = "\n选择要进行组合的单行文字 " + kws; // 当用户在命令行中输入A（或Add）时，命令行出现的提示字符。
+            pso.MessageForRemoval = pso.MessageForAdding;
+            // 当用户在命令行中输入Re（或Remove）时，命令行出现的提示字符。
+
+            // Finally run the selection and show any results
+            var psr = docMdf.acEditor.GetSelection(pso);
+
+            if (psr.Status == PromptStatus.OK)
+            {
+                return psr.Value.GetObjectIds();
+            }
+            return null;
+        }
+    }
+}

--- a/eZcad/Addins/DBTextsToMText.cs
+++ b/eZcad/Addins/DBTextsToMText.cs
@@ -23,7 +23,7 @@ namespace eZcad.Addins
     public class DBTextsToMText
     {
         /// <summary> 将单行文字转换为多行文字 </summary>
-        [CommandMethod("eZcad", "DBTextsToMText", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "DBTextsToMText", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void EcConvertDBTextsToMText()
         {
             DocumentModifier.ExecuteCommand(ConvertDBTextsToMText);
@@ -32,7 +32,7 @@ namespace eZcad.Addins
         /// <summary> 将单行文字转换为多行文字 </summary>
         public static void ConvertDBTextsToMText(DocumentModifier docMdf, SelectionSet impliedSelection)
         {
-            if (ManualMode(docMdf))
+           if (ManualMode(docMdf))
             {
                 ConvertInManualMode(docMdf);
             }

--- a/eZcad/Addins/DimAlignment.cs
+++ b/eZcad/Addins/DimAlignment.cs
@@ -6,6 +6,7 @@ using Autodesk.AutoCAD.EditorInput;
 using Autodesk.AutoCAD.Geometry;
 using Autodesk.AutoCAD.Runtime;
 using eZcad.Addins;
+using eZcad.Utility;
 
 // This line is not mandatory, but improves loading performances
 // 测试中，如果不使用下面这条，则在AutoCAD中对应的 External Command 不能正常加载。
@@ -18,7 +19,7 @@ namespace eZcad.Addins
     public class DimAlignment
     {
         /// <summary> 在新选择集中过滤出与当前选择集不相交的对象 </summary>
-        [CommandMethod("eZcad", "AlignDim", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "AlignDim", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void EcAlignDim()
         {
             DocumentModifier.ExecuteCommand(AlignDim);
@@ -88,9 +89,9 @@ namespace eZcad.Addins
         #region ---   界面交互
 
         /// <summary> 通过点选的方式选择一条曲线 </summary>
-        [CommandMethod("PickOneCurve")]
         public static Curve PickOneCurve(DocumentModifier docMdf)
         {
+
             // 点选
             var peO = new PromptEntityOptions("\n 选择一条曲线 ");
             peO.SetRejectMessage("\n 请选择一个曲线对象\n");

--- a/eZcad/Addins/DimTextScalor.cs
+++ b/eZcad/Addins/DimTextScalor.cs
@@ -21,7 +21,7 @@ namespace eZcad.Addins
     public class DimTextScalor
     {
         /// <summary> 将用户手动修改过的标注进行单位缩放 </summary>
-        [CommandMethod("eZcad", "ScaleDimText", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "ScaleDimText", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void EcScaleDimText()
         {
             DocumentModifier.ExecuteCommand(ScaleDimText);

--- a/eZcad/Addins/EcLoadTemplate1.cs
+++ b/eZcad/Addins/EcLoadTemplate1.cs
@@ -2,6 +2,7 @@
 using Autodesk.AutoCAD.EditorInput;
 using Autodesk.AutoCAD.Runtime;
 using eZcad.Addins;
+using eZcad.Utility;
 
 // This line is not mandatory, but improves loading performances
 // 测试中，如果不使用下面这条，则在AutoCAD中对应的 External Command 不能正常加载。
@@ -36,7 +37,7 @@ namespace eZcad.Addins
 
         #region --- 外部命令 - 实例 - 1
 
-        [CommandMethod("eZcad", "EcInstanceMethod1", CommandFlags.Modal)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "EcInstanceMethod1", CommandFlags.Modal)]
         public void EcInstanceMethod1() // This method can have any name
         {
             // 当用户第一次在 AutoCAD 界面中通过命令行调用此方法时，AutoCAD会通过此类的无参数构造函数创建出一个对应的实例A
@@ -54,8 +55,8 @@ namespace eZcad.Addins
         #endregion
 
         #region --- 外部命令 - 实例 - 2
-
-        [CommandMethod("eZcad", "EcInstanceMethod2", CommandFlags.Modal)]
+        
+        [CommandMethod(eZConstants.eZGroupCommnad, "EcInstanceMethod2", CommandFlags.Modal)]
         public void EcInstanceMethod2() // This method can have any name
         {
             // 当用户已经在 AutoCAD 界面中通过命令行调用过此类中的某实例 EcInstanceMethod1 后，再调用此 EcInstanceMethod2 时，
@@ -74,7 +75,7 @@ namespace eZcad.Addins
 
         #region --- 外部命令 - 静态 - 1
 
-        [CommandMethod("eZcad", "EcStaticeMethod1", CommandFlags.Modal)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "EcStaticeMethod1", CommandFlags.Modal)]
         public static void EcStaticeMethod1() // This method can have any name
         {
             // 当用户在 AutoCAD 界面中通过命令行调用过此类中的某静态 EcStaticeMethod 时，不会创建出此类的任何实例（也不需要），而是直接调用静态方法 EcLoad.EcStaticeMethod()。

--- a/eZcad/Addins/IntersectSelSet.cs
+++ b/eZcad/Addins/IntersectSelSet.cs
@@ -20,7 +20,7 @@ namespace eZcad.Addins
     {
 
         /// <summary> 在新选择集中过滤出与当前选择集不相交的对象 </summary>
-        [CommandMethod("eZcad", "IntersectSelSet", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "IntersectSelSet", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void EcIntersectSelSet()
         {
             DocumentModifier.ExecuteCommand(IntersectSelSet);

--- a/eZcad/Addins/PerpendicularLine.cs
+++ b/eZcad/Addins/PerpendicularLine.cs
@@ -40,7 +40,7 @@ namespace eZcad.Addins
 
         /// <summary> 为指定的曲线添加垂线 </summary>
         /// <param name="docMdf"></param>
-        [CommandMethod("eZcad", "AddPerpendicularLineOnACurve", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "AddPerpendicularLineOnACurve", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void AddPerpendicularLineOnACurve(DocumentModifier docMdf)
         {
             var curve = PickOneCurve(docMdf);

--- a/eZcad/Addins/PolyfaceToSubdmesh.cs
+++ b/eZcad/Addins/PolyfaceToSubdmesh.cs
@@ -16,7 +16,7 @@ namespace eZcad.Addins
     public class Polyface_SubDMesh_Convertor
     {
         /// <summary> 将多面网络转换为细分网格 </summary>
-        [CommandMethod("eZcad", "PolyfaceSubDMeshConvert", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "PolyfaceSubDMeshConvert", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void EcConvert()
         {
             DocumentModifier.ExecuteCommand(Convert);

--- a/eZcad/Addins/ReverseCurve.cs
+++ b/eZcad/Addins/ReverseCurve.cs
@@ -1,31 +1,33 @@
-﻿using System;
+﻿using System.Windows;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.EditorInput;
-using Autodesk.AutoCAD.Geometry;
 using Autodesk.AutoCAD.Runtime;
 using eZcad.Addins;
-
+using eZcad.Utility;
 
 // This line is not mandatory, but improves loading performances
-[assembly: CommandClass(typeof(CommonAddins))]
+
+[assembly: CommandClass(typeof (ReverseCurve))]
 
 namespace eZcad.Addins
 {
-    /// <summary> 获取指定的多段线上某点所对应的里程 </summary>
-    public class CommonAddins
+    /// <summary> 将指定的曲线的起始点反转 </summary>
+    public class ReverseCurve
     {
-        #region ---   在界面中获取对象
-
-        #endregion
-
-        #region ---   将指定的曲线的起始点反转
+        /// <summary> 将指定的曲线的起始点反转 </summary>
+        [CommandMethod(eZConstants.eZGroupCommnad, "ReverseCurve", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        public void EcReverseCurve()
+        {
+            DocumentModifier.ExecuteCommand(Execute);
+        }
 
         /// <summary> 将指定的曲线的起始点反转 </summary>
         /// <param name="docMdf"></param>
         /// <param name="impliedSelection"> 用户在执行方法之前已经选择好的对象。</param>
-        [CommandMethod("eZcad", "ReverseCurve", CommandFlags.Modal | CommandFlags.UsePickSet)]
-        public static void ReverseCurve(DocumentModifier docMdf, SelectionSet impliedSelection)
+        public static void Execute(DocumentModifier docMdf, SelectionSet impliedSelection)
         {
+            docMdf.acEditor.Command();
+
             Curve c = null;
             if (impliedSelection != null)
             {
@@ -54,15 +56,13 @@ namespace eZcad.Addins
                 c.DowngradeOpen();
             }
         }
-
-        #endregion
-
+        
         private static Curve PickOneCurve(DocumentModifier docMdf)
         {
             // 点选
             var peO = new PromptEntityOptions("\n 选择一条曲线 ");
             peO.SetRejectMessage("\n 请选择一个曲线对象\n");
-            peO.AddAllowedClass(typeof(Curve), exactMatch: false);
+            peO.AddAllowedClass(typeof (Curve), exactMatch: false);
 
             // 请求在图形区域选择对象
             var res = docMdf.acEditor.GetEntity(peO);

--- a/eZcad/Addins/RoadMileage.cs
+++ b/eZcad/Addins/RoadMileage.cs
@@ -34,7 +34,7 @@ namespace eZcad.Addins
         /// <summary> 为指定的曲线添加垂线 </summary>
         /// <param name="docMdf"></param>
         /// <param name="impliedSelection"> 用户在执行方法之前已经选择好的对象。</param>
-        [CommandMethod("eZcad", "GetRoadMileage", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "GetRoadMileage2", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void GetRoadMileage(DocumentModifier docMdf, SelectionSet impliedSelection)
         {
             _docMdf = docMdf;

--- a/eZcad/Addins/RoadMileageRS.cs
+++ b/eZcad/Addins/RoadMileageRS.cs
@@ -37,7 +37,7 @@ namespace eZcad.Addins
         /// <summary> 为指定的曲线添加垂线 </summary>
         /// <param name="docMdf"></param>
         /// <param name="impliedSelection"> 用户在执行方法之前已经选择好的对象。</param>
-        [CommandMethod("eZcad", "GetRoadMileage", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "GetRoadMileage1", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void GetRoadMileage(DocumentModifier docMdf, SelectionSet impliedSelection)
         {
             _docMdf = docMdf;

--- a/eZcad/Addins/TextScaler.cs
+++ b/eZcad/Addins/TextScaler.cs
@@ -21,7 +21,7 @@ namespace eZcad.Addins
     {
 
         /// <summary> 在新选择集中过滤出与当前选择集不相交的对象 </summary>
-        [CommandMethod("eZcad", "ScaleText", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "ScaleText", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void EcScaleText()
         {
             DocumentModifier.ExecuteCommand(ScaleText);

--- a/eZcad/Examples/GraphicalElementsCreator.cs
+++ b/eZcad/Examples/GraphicalElementsCreator.cs
@@ -21,7 +21,6 @@ namespace eZcad.Examples
         /// <param name="srcX">用来创建二维多段线的 X 集合</param>
         /// <param name="srcY">用来创建二维多段线的 Y 集合，其元素个数必须与 X 集合的元素个数相同 </param>
         /// <param name="close">是否要将整个多段线进行闭合</param>
-        [CommandMethod("AddPolyline")]
         public static void AddPolyline2D(double[] srcX, double[] srcY, bool close)
         {
             // 获得当前文档和数据库   Get the current document and database
@@ -81,7 +80,6 @@ namespace eZcad.Examples
         /// <param name="srcX">用来创建二维多段线的 X 集合</param>
         /// <param name="srcY">用来创建二维多段线的 Y 集合，其元素个数必须与 X 集合的元素个数相同 </param>
         /// <param name="close">是否要将整个多段线进行闭合</param>
-        [CommandMethod("AddPolyline")]
         public static void AddText(double[] srcX, double[] srcY, bool close)
         {
             using (DocumentModifier docMdf = new DocumentModifier(true))

--- a/eZcad/Examples/GraphicalElementsFilter.cs
+++ b/eZcad/Examples/GraphicalElementsFilter.cs
@@ -17,7 +17,6 @@ namespace eZcad.Examples
     /// <summary> 从用户选择集或者整个文档中过滤出指定信息的对象 </summary>
     internal static class GraphicalElementsFilter
     {
-        [CommandMethod("FindCirclesNoUI")]
         public static void FindCirclesNoUI()
         {
             // 获得当前文档和数据库   Get the current document and database

--- a/eZcad/Examples/GraphicalElementsModifier.cs
+++ b/eZcad/Examples/GraphicalElementsModifier.cs
@@ -20,7 +20,6 @@ namespace eZcad.Examples
     {
         /// <summary> 提示用户在界面中选择多个椭圆形，并将其转换为多段线 </summary>
         /// <remarks></remarks>
-        [CommandMethod("EllipseToPolyLine", CommandFlags.UsePickSet)]
         public static void EllipseToPolyLine()
         {
 
@@ -132,7 +131,6 @@ namespace eZcad.Examples
 
         /// <summary> 提示用户在界面中选择多个圆形，并将其转换为多段线 </summary>
         /// <remarks></remarks>
-        [CommandMethod("CircleToPolyLine", CommandFlags.UsePickSet)]
         public static void CircleToPolyLine()
         {
             // 获得当前文档和数据库   Get the current document and database

--- a/eZcad/Examples/GraphicalElementsSelector.cs
+++ b/eZcad/Examples/GraphicalElementsSelector.cs
@@ -19,7 +19,6 @@ namespace eZcad.Examples
     internal static class GraphicalElementsSelector
     {
 
-        [CommandMethod("FilterBlueCircleOnLayer0")]
         public static void GetSelection()
         {
             // 创建一个 TypedValue 数组，用于定义过滤条件
@@ -51,7 +50,6 @@ namespace eZcad.Examples
             }
         }
 
-        [CommandMethod("GetSelectionWithKeywords")]
         public static void GetSelectionWithKeywords()
         {
             Document doc = Application.DocumentManager.MdiActiveDocument;
@@ -87,7 +85,6 @@ namespace eZcad.Examples
             }
         }
 
-        [CommandMethod("GetAngleWithKeywords")]
         public static void GetAngleWithKeywords()
         {
             var doc = Application.DocumentManager.MdiActiveDocument;
@@ -218,7 +215,6 @@ namespace eZcad.Examples
         }
 
         /// <summary> 通过点选的方式选择一条曲线 </summary>
-        [CommandMethod("PickOneCurve")]
         public static Curve PickOneCurve(DocumentModifier docMdf)
         {
             // 点选

--- a/eZcad/Examples/XRecords_ResultBuffer.cs
+++ b/eZcad/Examples/XRecords_ResultBuffer.cs
@@ -1,0 +1,190 @@
+﻿using Autodesk.AutoCAD.ApplicationServices.Core;
+using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.EditorInput;
+using Autodesk.AutoCAD.Runtime;
+using eZcad.Examples;
+
+[assembly: CommandClass(typeof (XRecords_ResultBuffer))]
+
+namespace eZcad.Examples
+{
+    public class XRecords_ResultBuffer
+    {
+        /// <summary> 向 Entity 中添加数据 </summary>
+        [CommandMethod("AddDataToExtensionDictionary")]
+        public static void AddDataToExtensionDictionary()
+        {
+            Editor ed = Application.DocumentManager.MdiActiveDocument.Editor;
+            // pick entity to add data to! 
+            PromptEntityResult getEntityResult = ed.GetEntity("Pick an entity to add an Extension Dictionary to : ");
+            // if all was ok 
+            if ((getEntityResult.Status == PromptStatus.OK))
+            {
+                // now start a transaction 
+                Transaction trans = ed.Document.Database.TransactionManager.StartTransaction();
+                try
+                {
+                    // Start of Lab5 
+                    // Here we will add XData to a selected entity. 
+
+                    // 1. Declare an Entity variable named ent. Instantiate it using GetOBject of the Transaction created above. 
+                    Entity ent = (Entity) trans.GetObject(getEntityResult.ObjectId, OpenMode.ForRead);
+
+                    // 2. Use an "if" statement and test the IsNull property of the  ExtensionDictionary of the ent.
+                    if (ent.ExtensionDictionary.IsNull)
+                    {
+                        // 3. Upgrade the open of the entity. Because it does not have an extenstion dictionary and we want to add it the ent needs to be open for write. 
+                        ent.UpgradeOpen();
+
+                        // 4. Create the ExtensionDictionary by calling  CreateExtensionDictionary of the entity. 
+                        ent.CreateExtensionDictionary();
+                    }
+
+                    // 5. Declare a variable as DBDictionary. Instantiate it by using the GetObject method of the Transaction created above. 
+                    DBDictionary extensionDict =
+                        (DBDictionary) trans.GetObject(ent.ExtensionDictionary, OpenMode.ForRead);
+
+                    // 6. Check to see if the entry we are going to add to the dictionary is already there. Use the Contains property of the dictionary in an "if else statement.
+                    if (extensionDict.Contains("MyData"))
+                    {
+                        // 7. Declare an ObjectId variable named entryId and instantiate it using the GetAt method of the ExtenstionDictionary from step 5. Use "Mydata" for the entryName
+                        ObjectId entryId = extensionDict.GetAt("MyData");
+
+                        // 8. If this line gets hit then data is already added.
+                        ed.WriteMessage("\nThis entity already has data...");
+
+                        // 9. Now extract the Xrecord. Declare an Xrecord variable. 
+                        Xrecord myXrecord = default(Xrecord);
+
+                        // 10. Instantiate the Xrecord variable using the  GetObject method of the Transaction created above. 
+                        myXrecord = (Xrecord) trans.GetObject(entryId, OpenMode.ForRead);
+
+                        // 11. Here print out the values in the Xrecord to the command line. 
+                        ResultBuffer resBuff = myXrecord.Data;
+
+                        foreach (TypedValue value in resBuff)
+                        {
+                            // 12. Use the WriteMessage method of the Editor created above. (ed). 
+                            ed.WriteMessage("\n" + value.TypeCode.ToString() + " . " + value.Value.ToString());
+                        }
+                    }
+                    else
+                    {
+                        // 13. If the code gets to here then the data entry does not exist, upgrade the ExtensionDictionary created in step 5 to write by calling the UpgradeOpen() method 
+                        extensionDict.UpgradeOpen();
+
+                        // 14. Create a new XRecord. Declare an Xrecord variable as a New Xrecord 
+                        Xrecord myXrecord = new Xrecord();
+
+                        // 15. Create the resbuf list. Declare a ResultBuffer variable. Instantiate it by creating a New ResultBuffer.
+                        ResultBuffer data = new ResultBuffer(new TypedValue((int) DxfCode.Int16, 1),
+                            new TypedValue((int) DxfCode.Text, "MyStockData"),
+                            new TypedValue((int) DxfCode.Real, 51.9),
+                            new TypedValue((int) DxfCode.Real, 100.0),
+                            new TypedValue((int) DxfCode.Real, 320.6));
+
+                        // 16. Add the ResultBuffer to the Xrecord using the Data 
+                        // property of the Xrecord. (make it equal the ResultBuffer 
+                        // from step 15) 
+                        myXrecord.Data = data;
+
+                        // 17. Create the entry in the ExtensionDictionary. Use the SetAt  method of the ExtensionDictionary from step 5. 
+                        extensionDict.SetAt(searchKey: "MyData", newValue: myXrecord);
+
+                        // 18. Tell the transaction about the newly created Xrecord using the AddNewlyCreatedDBObject of the Transaction (trans) 
+                        trans.AddNewlyCreatedDBObject(myXrecord, true);
+                    }
+                    // all ok, commit it 
+                    trans.Commit();
+                }
+                catch (Exception ex)
+                {
+                    ed.WriteMessage("a problem occured because " + ex.Message);
+                }
+                finally
+                {
+                    // whatever happens we must dispose the transaction 
+                    trans.Dispose();
+                }
+            }
+        }
+
+        /// <summary> 向数据库中添加数据 </summary>
+        [CommandMethod("AddDataToNOD")]
+        public static void AddDataToNOD()
+        {
+            // get the editor object 
+            Editor ed = Application.DocumentManager.MdiActiveDocument.Editor;
+            // pick entity to add data to! 
+            Transaction trans = ed.Document.Database.TransactionManager.StartTransaction();
+            try
+            {
+                // 26. Here we will add our data to the Named Objects Dictionary.(NOD). Declare a variable as a DBDictionary. (name it nod).
+                DBDictionary nod =
+                    (DBDictionary) trans.GetObject(ed.Document.Database.NamedObjectsDictionaryId, OpenMode.ForRead);
+
+                // 27. Check to see if the entry we are going to add to the NOD is  already there. 
+                if (nod.Contains("MyData"))
+                {
+                    // 28. Declare an ObjectId variable named entryId. Instantiate it by making it equal to the return of the GetAt method of the NOD (DBDictionary) 
+                    ObjectId entryId = nod.GetAt("MyData");
+
+                    // 29. If we are here, then the Name Object Dictionary already has our data.
+                    ed.WriteMessage("\n" + "This entity already has data...");
+
+                    // 30. Get the the Xrecord from the NOD. Declare a variable as a new Xrecord 
+                    Xrecord myXrecord = null;
+
+                    // 31. USe the Transaction (trans) and use the GetObject method to get the the Xrecord from the NOD.
+                    myXrecord = (Xrecord) trans.GetObject(entryId, OpenMode.ForRead);
+
+                    // 32. Print out the values of the Xrecord to the command line.
+                    foreach (TypedValue value in myXrecord.Data)
+                    {
+                        // 33. Use the WriteMessage method of the editor. 
+                        ed.WriteMessage("\n" + value.TypeCode.ToString() + " . " + value.Value.ToString());
+                    }
+                }
+                else
+                {
+                    // 34. Our data is not in the Named Objects Dictionary so need to add it 
+                    // upgrade the status of the NOD variable from step 26 to write status 
+                    nod.UpgradeOpen();
+
+                    // 35. Declare a varable as a new Xrecord. 
+                    Xrecord myXrecord = new Xrecord();
+
+                    // 36. Create the resbuf list. Declare a ResultBuffer variable. Instantiate it  by creating a New ResultBuffer.
+                    ResultBuffer data = new ResultBuffer(new TypedValue((int) DxfCode.Int16, 1),
+                        new TypedValue((int) DxfCode.Text, "MyCompanyDefaultSettings"),
+                        new TypedValue((int) DxfCode.Real, 51.9),
+                        new TypedValue((int) DxfCode.Real, 100.0),
+                        new TypedValue((int) DxfCode.Real, 320.6));
+
+                    // 37. Add the ResultBuffer to the Xrecord using the Data property of the Xrecord.
+                    myXrecord.Data = data;
+
+                    // 38. Create the entry in the ExtensionDictionary. Use the SetAt method of the Named Objects Dictionary from step 26.
+                    nod.SetAt(searchKey: "MyData", newValue: myXrecord);
+
+                    // 39. Tell the transaction about the newly created Xrecord. 
+                    trans.AddNewlyCreatedDBObject(myXrecord, true);
+                }
+
+                // End of LAB 5
+
+                // all ok, commit it 
+                trans.Commit();
+            }
+            catch (Exception ex)
+            {
+                ed.WriteMessage("a problem occurred because " + ex.Message);
+            }
+            finally
+            {
+                // whatever happens we must dispose the transaction 
+                trans.Dispose();
+            }
+        }
+    }
+}

--- a/eZcad/Properties/AssemblyInfo.cs
+++ b/eZcad/Properties/AssemblyInfo.cs
@@ -11,9 +11,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("AutoCADDev")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("XN")]
+[assembly: AssemblyCompany("SJTU")]
 [assembly: AssemblyProduct("AutoCADDev")]
-[assembly: AssemblyCopyright("Copyright © XN 2016")]
+[assembly: AssemblyCopyright("Copyright © SJTU 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // In order to sign your assembly you must specify a key to use. Refer to the 

--- a/eZcad/Utility/EntityArray2D.cs
+++ b/eZcad/Utility/EntityArray2D.cs
@@ -1,0 +1,319 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.Geometry;
+
+namespace eZcad.Utility
+{
+    public class EntityArray2D<T> where T : Entity
+    {
+        #region   ---   Fields
+
+        private readonly IEnumerable<T> _entities;
+
+        #endregion
+
+        public EntityArray2D(IEnumerable<T> entities)
+        {
+            _entities = entities;
+        }
+
+        /// <summary>
+        /// 将集合中的元素在二维平面中进行分格填空，以形成一个按二维几何排布的数组
+        /// 每一个方格中可能有多个实体，比如多个文字挤在一堆。第(0,0)个元素代表位于几何坐标系中的靠左上角的元素们。
+        /// </summary>
+        /// <returns>考虑到AutoCAD几何坐标系中，Y坐标较小者位于集合前面，而在计算机的二维数组表示方法中，
+        /// 下标(0,0)一般表示位于左上角的元素，所以，这里在将几何元素填充到二维数组中时，将Y值的排序进行反转。</returns>
+        public List<T>[,] Arrange2D()
+        {
+            var entBounds = new List<EntBound>();
+            foreach (var e in _entities)
+            {
+                if (e.Bounds.HasValue)
+                {
+                    entBounds.Add(new EntBound(e, new Rectangle2D(e.Bounds.Value.MinPoint, e.Bounds.Value.MaxPoint)));
+                }
+            }
+            // 求出每一个实体在最终的二维方格中的定位下标，第一个方格的下标为 0
+            int rowsCount, colsCount;
+            var rowEnts = SortToOneVector(true, entBounds, out colsCount);  // 将所有元素压缩到一行，字典中的值对应二维数组中的列号
+            var colEnts = SortToOneVector(false, entBounds, out rowsCount); // 将所有元素压缩到一列，字典中的值对应二维数组中的行号
+
+            // 每一个方格中可能有多个实体，比如多个文字挤在一堆
+            var res = new List<T>[rowsCount, colsCount];
+            for (int r = 0; r < rowsCount; r++)  // 将二维集合中所有方格都初始化一个集合
+            {
+                for (int c = 0; c < colsCount; c++)
+                {
+                    res[r, c] = new List<T>();
+                }
+            }
+
+            int rowIndex, colIndex;
+            foreach (var ent in entBounds)
+            {
+                // 从压缩到的一整行中提取每一个元素的列号
+                colIndex = rowEnts[ent];
+                // 从压缩到的一整列中提取每一个元素的行号，同时，考虑到AutoCAD几何坐标系中，Y坐标较小者位于集合前面，而在计算机的二维数组表示方法中，下标(0,0)一般表示位于左上角的元素，所以，这里在将几何元素填充到二维数组中时，将Y值的排序进行反转。
+                rowIndex = rowsCount - 1 - colEnts[ent]; 
+                // 为二维方格中添加实体
+                res[rowIndex, colIndex].Add(ent.Entity);
+            }
+            return res;
+        }
+
+        #region   ---   排列多个矩形
+
+        /// <summary> 将集合中的元素排列到一行或一列中（紧密算法，即相交实体的认为在同一行或同一列） </summary>
+        /// <param name="inRow">true 表示将集合中的元素排列到一行中，false 表示将集合中的实体排列到一列中 </param>
+        /// <param name="entities"></param>
+        /// <param name="count">排列完成后，共有多少行或者多少列</param>
+        /// <returns>返回的字典中，键表示每一个实体对象，值代表此对象在排列好的行中的下标，第一个值的下标为0。多个实体可能对应同一个下标</returns>
+        private static Dictionary<EntBound, int> SortToOneVector(bool inRow, List<EntBound> entities, out int count)
+        {
+            if (entities.Count == 0)
+            {
+                count = 0;
+                return new Dictionary<EntBound, int>();
+            }
+            else if (entities.Count == 1)
+            {
+                count = 1;
+                return new Dictionary<EntBound, int> { { entities.First(), 0 } };
+            }
+            else // 集合中至少有两个元素
+            {
+                var firstEnt = entities.First();
+                // 相互分隔的矩形区域，前面的元素位置靠下/左
+                var sepratedSortedBounds = new SortedDictionary<double, Rectangle2D> { { 0, firstEnt.Bound } };
+                var sortedEntIndex = new Dictionary<EntBound, double> { { firstEnt, 0 } };
+
+                // 从第二个元素开始添加
+                for (int i = 1; i < entities.Count; i++)
+                {
+                    var ent = entities[i];
+                    InsertEntityToOneVec(inRow, sepratedSortedBounds, sortedEntIndex, ent);
+                }
+                // 将表示定位的 double 值转换为 int 值
+                var indices = sortedEntIndex.Values.Distinct().ToArray();
+                Array.Sort(indices);
+                var res = new Dictionary<EntBound, int>();
+                foreach (var ent in sortedEntIndex)
+                {
+                    var ind = Array.IndexOf(indices, ent.Value);
+                    res.Add(ent.Key, ind);
+                }
+                count = indices.Length;
+                return res;
+            }
+        }
+
+        /// <summary> 将新的实体在原集合中按是否在同一列进行插值，即将所有的元素压缩到同一行中 </summary>
+        /// <param name="inRow"> true 表示将新的实体在原集合中按是否在同一列进行插值，即将所有的元素压缩到同一行中；
+        /// false 表示 将新的实体在原集合中按是否在同一行进行插值，即将所有的元素压缩到同一列中 </param>
+        /// <param name="sepratedSortedBounds"></param>
+        /// <param name="sortedEntIndex"></param>
+        /// <param name="newEnt"></param>
+        private static void InsertEntityToOneVec(bool inRow, SortedDictionary<double, Rectangle2D> sepratedSortedBounds,
+            Dictionary<EntBound, double> sortedEntIndex, EntBound newEnt)
+        {
+            IntersectState s;
+            double lastIndex = sepratedSortedBounds.First().Key;
+
+            var i = 0;
+            foreach (var index in sepratedSortedBounds.Keys) // 从左到右一个一个给出来与新实体进行比较
+            {
+                var rec = sepratedSortedBounds[index];
+                // --------------------------------------------------------
+                if (inRow)
+                {
+                    s = rec.ColumnIntersectWith(newEnt.Bound);
+                }
+                else
+                {
+                    s = rec.RowIntersectWith(newEnt.Bound);
+                }
+
+                // --------------------------------------------------------
+                if ((s & IntersectState.Intersect) > 0) // 在相交的情况下，直接将其放到同一列中
+                {
+                    //index = sepratedSortedBounds[bd];
+                    sortedEntIndex.Add(newEnt, index);
+                    return;
+                }
+                else if (s == IntersectState.OBottom) // 由于比较对象是从下往上给出来的，所以如果新实体位于集合中某矩形的下方，则找到了其定位
+                {
+                    double newId = 0;
+                    if (i == 0)
+                    {
+                        newId = index - 1;  // 集合中 第一个进行比较的位于最左边，其编号最小，此时将新index取为直接减1。
+                    }
+                    else
+                    {
+                        newId = (lastIndex + index) / 2; // 用二分法进行定位的插值
+                    }
+                    sepratedSortedBounds.Add(newId, newEnt.Bound);
+                    sortedEntIndex.Add(newEnt, newId);
+                    return;
+                }
+                else // 不相交，而且新实体在集合元素的上方（右边）
+                {
+                }
+                i += 1;
+                lastIndex = index;
+            }
+            // 如果执行到这里，说明新实体在集合中所有实体的右边（上方）
+            var newIndex = lastIndex + 1;
+            sepratedSortedBounds.Add(newIndex, newEnt.Bound);
+            sortedEntIndex.Add(newEnt, newIndex);
+        }
+
+        #endregion
+
+        #region   ---   Types: EntBound
+
+        private class EntBound
+        {
+            public T Entity { get; set; }
+            public Rectangle2D Bound { get; set; }
+
+            public EntBound(T entity, Rectangle2D bound)
+            {
+                Entity = entity;
+                Bound = bound;
+            }
+
+            public override string ToString()
+            {
+                if (Entity is DBText)
+                {
+                    return (Entity as DBText).TextString;
+                }
+                else
+                {
+                    return base.ToString();
+                }
+            }
+        }
+
+        #endregion
+    }
+
+    #region   ---   Types: Rectangle2D
+
+    /// <summary>
+    /// 二维矩形方框区域
+    /// </summary>
+    public class Rectangle2D
+    {
+        #region   ---   Fields
+
+        public readonly double Left;
+        public readonly double Top;
+        public readonly double Bottom;
+        public readonly double Right;
+        public readonly double Height;
+        public readonly double Width;
+
+        #endregion
+
+        public Rectangle2D(Point2d pt1, Point2d pt2)
+        {
+            Left = Math.Min(pt1.X, pt2.X);
+            Right = Math.Max(pt1.X, pt2.X);
+            Top = Math.Max(pt1.Y, pt2.Y);
+            Bottom = Math.Min(pt1.Y, pt2.Y);
+            Height = Top - Bottom;
+            Width = Right - Left;
+        }
+
+        public Rectangle2D(Point3d pt1, Point3d pt2)
+        {
+            Left = Math.Min(pt1.X, pt2.X);
+            Right = Math.Max(pt1.X, pt2.X);
+            Top = Math.Max(pt1.Y, pt2.Y);
+            Bottom = Math.Min(pt1.Y, pt2.Y);
+            Height = Top - Bottom;
+            Width = Right - Left;
+        }
+
+        #region   ---   矩形区域的相交关系
+
+        /// <summary> 比较 Y 值，以确定是否在同一行 </summary>
+        /// <param name="recB"></param>
+        /// <returns></returns>
+        public IntersectState RowIntersectWith(Rectangle2D recB)
+        {
+            return IntersectWith(Bottom, Top, recB.Bottom, recB.Top);
+        }
+
+        /// <summary> 比较 X 值，以确定是否在同一列 </summary>
+        public IntersectState ColumnIntersectWith(Rectangle2D recB)
+        {
+            return IntersectWith(Left, Right, recB.Left, recB.Right);
+        }
+
+        private IntersectState IntersectWith(double bottom1, double top1, double bottom2, double top2)
+        {
+            const double tol = 1e-8;
+            if (bottom2 >= top1) return IntersectState.OTop;
+            else if (top2 <= bottom1) return IntersectState.OBottom;
+            else if (top2 <= bottom1) return IntersectState.OBottom;
+            else if ((Math.Abs(top1 - top2) < tol) && (Math.Abs(bottom1 - bottom2) < tol))
+                return IntersectState.ICoinside;
+            else if (top2 >= top1 && bottom2 >= bottom1) return IntersectState.ITop;
+            else if (top2 <= top1 && bottom2 <= bottom1) return IntersectState.IBottom;
+            else if (top2 <= top1 && bottom2 >= bottom1) return IntersectState.IInside;
+            else if (top2 >= top1 && bottom2 <= bottom1) return IntersectState.IContain;
+            else return IntersectState.Others;
+        }
+
+        #endregion
+
+    }
+
+    #endregion
+
+    #region   ---   Types: IntersectState
+
+    /// <summary>
+    /// 两个矩形之间的相交关系。
+    /// 对于左右的比较，左即对应于下，右即对应于上。
+    /// </summary>
+    [Flags]
+    public enum IntersectState : short
+    {
+        Others = 0,
+
+        /// <summary> B 与 A 相交面积不为0 </summary>
+        Intersect = 1,
+
+        /// <summary> B 与 A 相交，而且B的最上边比A的最上边高 </summary>
+        ITop = Intersect | 2,
+
+        /// <summary> B 与 A 相交，而且B的最下边比A的最下边低 </summary>
+        IBottom = Intersect | 4,
+
+        /// <summary> A 完全将 B 包含 </summary>
+        IInside = Intersect | 8,
+
+        /// <summary> B 完全将 A 包含 </summary>
+        IContain = Intersect | 16,
+
+        /// <summary> B 与 A 完全重合 </summary>
+        ICoinside = Intersect | 32,
+
+        /// <summary> B 与 A 相交面积为 0  </summary>
+        Apart = 64,
+
+        /// <summary> B 在 A 的上方，不相交或者只有边界相交 </summary>
+        OTop = Apart | 128,
+
+        /// <summary> B 在 A 的下方，不相交或者只有边界相交 </summary>
+        OBottom = Apart | 256,
+    }
+
+    #endregion
+
+}

--- a/eZcad/Utility/eZConstants.cs
+++ b/eZcad/Utility/eZConstants.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autodesk.AutoCAD.Runtime;
+
+namespace eZcad.Utility
+{
+    public static class eZConstants
+    {
+        /// <summary>
+        /// 在<see cref="CommandMethodAttribute"/>中设置的外部命令的 GroupName。
+        /// </summary>
+        public const string eZGroupCommnad = "eZcad";
+    }
+}

--- a/eZcad/Utility/utils.cs
+++ b/eZcad/Utility/utils.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.Geometry;
-using Autodesk.AutoCAD.Runtime;
 using Microsoft.Win32;
 
 namespace eZcad.Utility
@@ -58,7 +57,7 @@ namespace eZcad.Utility
                 foreach (ObjectId idTemp in block)
                 {
                     // 判断该实体是否是块定义 ，也可以以块定义方式打开，但是会产生事物嵌套  
-                    if (idTemp.ObjectClass.Equals(RXObject.GetClass(typeof(AttributeDefinition))))
+                    if (idTemp.ObjectClass.Equals(Autodesk.AutoCAD.Runtime.RXObject.GetClass(typeof(AttributeDefinition))))
                     {
                         AttributeDefinition adDef = tr.GetObject(idTemp, OpenMode.ForRead) as AttributeDefinition;
                         if (adDef != null)

--- a/eZcad/eZcad.csproj
+++ b/eZcad/eZcad.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>eZcad</RootNamespace>
     <AssemblyName>eZcad</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <FileUpgradeFlags>
@@ -33,6 +33,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,6 +45,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\bin\eZcad.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,6 +55,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -63,6 +66,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -72,32 +76,32 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>
     </StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="accoremgd">
-      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2014\accoremgd.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="acdbmgd">
-      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2014\acdbmgd.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="AcMgd, Version=19.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <Private>False</Private>
-      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2014\acmgd.dll</HintPath>
-    </Reference>
     <!--ACA References Begin-->
     <!--ACA Refences End-->
     <!--AME Referebces Begin-->
     <!--AME Reference End-->
+    <Reference Include="accoremgd">
+      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2016\accoremgd.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="acdbmgd">
+      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2016\acdbmgd.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="acmgd">
+      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2016\acmgd.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="eZcad_AddinManager">
       <HintPath>..\eZcad_AddinManager\bin\Debug\eZcad_AddinManager.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Office.Interop.Excel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
@@ -122,7 +126,8 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Addins\CommonAddins.cs" />
+    <Compile Include="Addins\CombineDbTexts.cs" />
+    <Compile Include="Addins\ReverseCurve.cs" />
     <Compile Include="Addins\PolyfaceToSubdmesh.cs" />
     <Compile Include="Addins\EcLoadTemplate1.cs" />
     <Compile Include="Addins\DimAlignment.cs" />
@@ -133,6 +138,7 @@
     <Compile Include="Debug\AddinManagerDebuger.cs" />
     <Compile Include="Debug\Ec_Addins.cs" />
     <Compile Include="Debug\Ec_Boundary.cs" />
+    <Compile Include="Debug\Ec_FormatDbTexts.cs" />
     <Compile Include="Debug\Ec_ProxyEntity.cs" />
     <Compile Include="Debug\Ec_GeoMesh.cs" />
     <Compile Include="Debug\Ec_DimStyles.cs" />
@@ -165,6 +171,7 @@
     <Compile Include="Examples\GraphicalElementsModifier.cs" />
     <Compile Include="Examples\LayerHandler.cs" />
     <Compile Include="Examples\SolidHandler.cs" />
+    <Compile Include="Examples\XRecords_ResultBuffer.cs" />
     <Compile Include="myCommands.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -174,7 +181,9 @@
     <Compile Include="myCommands.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Addins\TableDataGetter.cs" />
+    <Compile Include="Utility\EntityArray2D.cs" />
     <Compile Include="Utility\ExtensionMethods.cs" />
+    <Compile Include="Utility\eZConstants.cs" />
     <Compile Include="Utility\SolidUtils.cs" />
     <Compile Include="Utility\TextUtils.cs" />
     <Compile Include="Utility\Utils.cs" />
@@ -210,7 +219,7 @@
   </ItemGroup>
   <ItemGroup>
     <COMReference Include="AutoCAD">
-      <Guid>{D5C3CB6F-AA0A-4D45-B02D-CF2974EFD4BE}</Guid>
+      <Guid>{4E3F492A-FB57-4439-9BF0-1567ED84A3A9}</Guid>
       <VersionMajor>1</VersionMajor>
       <VersionMinor>0</VersionMinor>
       <Lcid>0</Lcid>

--- a/eZcad/myCommands.cs
+++ b/eZcad/myCommands.cs
@@ -6,6 +6,7 @@ using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.Geometry;
 using Autodesk.AutoCAD.EditorInput;
+using eZcad.Utility;
 
 // This line is not mandatory, but improves loading performances
 // 测试中，如果不使用下面这条，则在AutoCAD中对应的 External Command 不能正常加载。
@@ -30,7 +31,7 @@ namespace eZcad
         // context menu.
 
         // Modal Command with localized name
-        [CommandMethod("MyGroup", "MyCommand", "MyCommandLocal", CommandFlags.Modal)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "MyCommand", "MyCommandLocal", CommandFlags.Modal)]
         public void MyCommand() // This method can have any name
         {
            // Put your command code here
@@ -38,7 +39,7 @@ namespace eZcad
         }
         
         // Modal Command with pickfirst selection
-        [CommandMethod("MyGroup", "MyPickFirst", "MyPickFirstLocal", CommandFlags.Modal | CommandFlags.UsePickSet)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "MyPickFirst", "MyPickFirstLocal", CommandFlags.Modal | CommandFlags.UsePickSet)]
         public void MyPickFirst() // This method can have any name
         {
             PromptSelectionResult result = Application.DocumentManager.MdiActiveDocument.Editor.GetSelection();
@@ -55,7 +56,7 @@ namespace eZcad
         }
 
         // Application Session Command with localized name
-        [CommandMethod("MyGroup", "MySessionCmd", "MySessionCmdLocal", CommandFlags.Modal | CommandFlags.Session)]
+        [CommandMethod(eZConstants.eZGroupCommnad, "MySessionCmd", "MySessionCmdLocal", CommandFlags.Modal | CommandFlags.Session)]
         public void MySessionCmd() // This method can have any name
         {
             // Put your command code here

--- a/eZcad/myPlugin.cs
+++ b/eZcad/myPlugin.cs
@@ -39,6 +39,7 @@ namespace eZcad
             // as well as some of the existing AutoCAD managed apps.
 
             // Initialize your plug-in application here
+            var ed = Application.DocumentManager.MdiActiveDocument.Editor;
         }
 
         void IExtensionApplication.Terminate()

--- a/eZcad_AddinManager/Addins/AutoSwitchIME.cs
+++ b/eZcad_AddinManager/Addins/AutoSwitchIME.cs
@@ -33,7 +33,6 @@ namespace eZcad.Addins
             "MLEADERCONTENTEDIT", // 编辑 多重引线
             "TEXTEDIT", // 编辑 标注文字
         };
-
         #endregion
 
         public AutoSwitchIME()

--- a/eZcad_AddinManager/Addins/Class1.cs
+++ b/eZcad_AddinManager/Addins/Class1.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Autodesk.AutoCAD.ApplicationServices;
+using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.EditorInput;
+using Autodesk.AutoCAD.Runtime;
+using eZcad.AddinManager;
+using eZcad.Addins;
+
+[assembly: CommandClass(typeof(NetLoadTest))]
+
+namespace eZcad.Addins
+{
+    public class NetLoadTest
+    {
+        [CommandMethod("MNL")]
+        public static void MyNetLoad()
+        {
+
+            Document doc = Application.DocumentManager.MdiActiveDocument;
+            Editor ed = doc.Editor;
+            PromptStringOptions pso = new PromptStringOptions("\n输入要加载的程序集全路径: ");
+            pso.AllowSpaces = true;
+            PromptResult pr = ed.GetString(pso);
+            if (pr.Status != PromptStatus.OK)
+            {
+                return;
+            }
+            try
+            {
+                //
+                byte[] buff = File.ReadAllBytes(pr.StringResult);
+                //先将插件拷贝到内存缓冲。一般情况下，当加载的文件大小大于2^32 byte (即4.2 GB），就会出现OutOfMemoryException，在实际测试中的极限值为630MB。
+                var ass = Assembly.Load(buff);
+                //  var ass = Assembly.LoadFile(pr.StringResult);
+
+                //var ass = System.Reflection.Assembly.LoadFrom(pr.StringResult);
+            }
+            catch (System.Exception ex)
+            {
+                ed.WriteMessage("\n无法加载程序集{0}: {1}", pr.StringResult, ex.Message);
+            }
+        }
+    }
+
+    [EcDescription("AddinManager 调试代码模板")]
+    public class Ec_DebugTemplate123321 : ICADExCommand
+    {
+        public ExternalCommandResult Execute(SelectionSet impliedSelection, ref string errorMessage,
+             ref IList<ObjectId> elementSet)
+        {
+            return ExternalCommandResult.Succeeded;
+        }
+    }
+}

--- a/eZcad_AddinManager/Addins/CmdDuplicatesFinder.cs
+++ b/eZcad_AddinManager/Addins/CmdDuplicatesFinder.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Windows.Forms;
+using Autodesk.AutoCAD.ApplicationServices;
+using Autodesk.AutoCAD.EditorInput;
+using Autodesk.AutoCAD.Runtime;
+using eZcad.Addins;
+using Application = Autodesk.AutoCAD.ApplicationServices.Core.Application;
+using Exception = System.Exception;
+
+[assembly: CommandClass(typeof(CmdDuplicatesFinder))]
+// [assembly: PerDocumentClass(typeof(CmdDuplicatesFinder))]
+
+namespace eZcad.Addins
+{
+    class CmdDuplicatesFinder
+    {
+        [CommandMethod("FindCmdDuplicates")]
+        public void FindCmdDuplicatesCmd()
+        {
+            string asmPath = SelectAssembly();
+
+            if (asmPath == null)
+                return;
+
+            FindCmdDuplicates(asmPath);
+        }
+
+        private string SelectAssembly()
+        {
+            OpenFileDialog dlg = new OpenFileDialog();
+
+            dlg.Title = "Load Assembly File";
+
+            dlg.InitialDirectory = Environment.GetFolderPath(
+                Environment.SpecialFolder.Desktop);
+
+            dlg.Filter = ".Net Assembly (*.dll)|*.dll";
+            dlg.FilterIndex = 1;
+            dlg.RestoreDirectory = true;
+
+            while (dlg.ShowDialog() == DialogResult.OK)
+            {
+                try
+                {
+                    AssemblyName asmName =
+                        AssemblyName.GetAssemblyName(dlg.FileName);
+
+                    return dlg.FileName;
+                }
+                catch (BadImageFormatException ex)
+                {
+                    MessageBox.Show(
+                        "Sorry the file is not a valid .Net assembly...",
+                        "Invalid Assembly",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+            }
+
+            return null;
+        }
+
+        public void FindCmdDuplicates(string asmPath)
+        {
+
+            Document doc = Application.DocumentManager.MdiActiveDocument;
+            Editor ed = doc.Editor;
+
+            Assembly asm = Assembly.LoadFile(asmPath);
+
+            Type[] expTypes;
+            var errTypes = new Exception[0];
+            try
+            {
+                expTypes = asm.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                errTypes = ex.LoaderExceptions;
+                expTypes = ex.Types;
+            }
+
+            var map = new Dictionary<string, List<MethodInfo>>();
+
+            try
+            {
+                //
+                foreach (Type type in expTypes)
+                {
+                    if (type == null){continue;}
+
+                    MethodInfo[] methods = type.GetMethods();
+
+                    foreach (MethodInfo method in methods)
+                    {
+                        CommandMethodAttribute attribute =
+                            GetCommandMethodAttribute(method);
+
+                        if (attribute == null)
+                            continue;
+
+                        if (!map.ContainsKey(attribute.GlobalName))
+                        {
+                            var methodInfo = new List<MethodInfo>();
+
+                            map.Add(attribute.GlobalName, methodInfo);
+                        }
+
+                        map[attribute.GlobalName].Add(method);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message + ex.StackTrace);
+            }
+
+            // 查看加载出错的类
+            foreach (Exception ex in errTypes)
+            {
+                ed.WriteMessage($"\n{ex.Message}");
+            }
+            // 查看重新的类
+            foreach (var keyValuePair in map)
+            {
+                if (keyValuePair.Value.Count > 1)
+                {
+                    ed.WriteMessage(
+                        "\nDuplicate Attribute: " + keyValuePair.Key);
+
+                    foreach (var method in keyValuePair.Value)
+                    {
+                        ed.WriteMessage(
+                            "\n – Method: " + method.Name);
+                    }
+                }
+            }
+        }
+
+        public CommandMethodAttribute GetCommandMethodAttribute(MethodInfo method)
+        {
+            object[] attributes = method.GetCustomAttributes(true);
+
+            foreach (object attribute in attributes)
+            {
+                if (attribute is CommandMethodAttribute)
+                {
+                    return attribute as CommandMethodAttribute;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/eZcad_AddinManager/Addins/EcLoadTemplate1.cs
+++ b/eZcad_AddinManager/Addins/EcLoadTemplate1.cs
@@ -36,7 +36,7 @@ namespace eZcad.Addins
 
         #region --- 外部命令 - 实例 - 1
 
-        [CommandMethod("eZcad", "EcInstanceMethod1", CommandFlags.Modal)]
+        [CommandMethod("eZcad", "EcInstanceMethod10", CommandFlags.Modal)]
         public void EcInstanceMethod1() // This method can have any name
         {
             // 当用户第一次在 AutoCAD 界面中通过命令行调用此方法时，AutoCAD会通过此类的无参数构造函数创建出一个对应的实例A
@@ -55,7 +55,7 @@ namespace eZcad.Addins
 
         #region --- 外部命令 - 实例 - 2
 
-        [CommandMethod("eZcad", "EcInstanceMethod2", CommandFlags.Modal)]
+        [CommandMethod("eZcad", "EcInstanceMethod20", CommandFlags.Modal)]
         public void EcInstanceMethod2() // This method can have any name
         {
             // 当用户已经在 AutoCAD 界面中通过命令行调用过此类中的某实例 EcInstanceMethod1 后，再调用此 EcInstanceMethod2 时，
@@ -74,7 +74,7 @@ namespace eZcad.Addins
 
         #region --- 外部命令 - 静态 - 1
 
-        [CommandMethod("eZcad", "EcStaticeMethod1", CommandFlags.Modal)]
+        [CommandMethod("eZcad", "EcStaticeMethod10", CommandFlags.Modal)]
         public static void EcStaticeMethod1() // This method can have any name
         {
             // 当用户在 AutoCAD 界面中通过命令行调用过此类中的某静态 EcStaticeMethod 时，不会创建出此类的任何实例（也不需要），而是直接调用静态方法 EcLoad.EcStaticeMethod()。

--- a/eZcad_AddinManager/AssemblyLoader/AssemblyLoader.cs
+++ b/eZcad_AddinManager/AssemblyLoader/AssemblyLoader.cs
@@ -142,7 +142,7 @@ namespace eZcad.AddinManager
         /// <summary> 将程序集加载到程序中 </summary>
         /// <param name="filePath">程序集的文件路径</param>
         /// <returns></returns>
-        private Assembly LoadAddin(string filePath)
+        private  Assembly LoadAddin(string filePath)
         {
             Assembly result = null;
             try

--- a/eZcad_AddinManager/AssemblyLoader/eZAssemblyLoader.cs
+++ b/eZcad_AddinManager/AssemblyLoader/eZAssemblyLoader.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using eZcad.AddinManager;
+
+namespace eZcad.AssemblyLoader
+{
+    /// <summary>
+    /// 为了将要加载的程序集中的外部命令显示到<see cref="form_AddinManager"/>窗口中，
+    /// 在加载程序集时（只是加载程序集，而不是调用程序集中的外部命令时），可能会出现“未能加载文件或程序集“Accessibility,Version=2.0.0.0，Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a”或它的某一个依赖项。系统找不到指定文件。”这种报错。
+    /// 此时要利用  AppDomain.CurrentDomain.AssemblyResolve  事件进行解决。
+    /// </summary>
+    /// <remarks>此类由Zengfy参照<see cref="AssemLoader"/>类自行编写，即为了解决在 AutoCAD 2016 中，AddinManager Load 程序集时，总是出现
+    /// “未能加载文件或程序集“Accessibility,Version=2.0.0.0，Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a”或它的某一个依赖项。系统找不到指定文件。”
+    /// 这种报错的问题。在AutoCAD 2014 的开发中并不需要。</remarks>
+    public class eZAssemblyLoader
+    {
+        #region ---   Fields
+        /// <summary> 要进行加载的主程序集所在的文件夹 </summary>
+        private readonly string _srcDir;
+        /// <summary> 要进行加载的主程序集的名称，比如 eZcad.dll </summary>
+        private readonly string _srcDll;
+
+        /// <summary> 是否为当前程序域中添加了新的程序集 </summary>
+        private bool _newAssemblyAddedToAppDomain;
+        /// <summary> 当前程序域中已经加载的程序集 </summary>
+        private Assembly[] _appDomainAssemblies;
+
+        #endregion
+
+        public eZAssemblyLoader(string srcDllPath)
+        {
+            _srcDir = Path.GetDirectoryName(srcDllPath);
+            _srcDll = Path.GetFileName(srcDllPath);
+        }
+
+        #region ---   HookAssemblyResolve ：以异常处理的方式加载不能正常引用的程序集
+
+        /// <summary>
+        /// AssemblyResolve事件在.Net对程序集的解析失败时触发，返回一个Assembly对象。
+        /// 因此，我们只要在这个事件的处理程序里手动加载对应目录的dll，并把对应dll的Assembly对象返回， .Net就能正确加载对应的dll了。
+        /// </summary>
+        /// <remarks></remarks>
+        public void HookAssemblyResolve()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(this.CurrentDomain_AssemblyResolve);
+        }
+
+        public void UnhookAssemblyResolve()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve -= new ResolveEventHandler(this.CurrentDomain_AssemblyResolve);
+        }
+
+
+        /// <summary> 在 Execute() 方法中将不能引用到的程序集进行手动加载 </summary>
+        /// <param name="sender"></param>
+        /// <param name="args"></param>
+        /// <returns>返回的程序集即作为调用的程序集，即使返回的程序集并不是想要的那一个。</returns>
+        private Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            if (_appDomainAssemblies == null || _newAssemblyAddedToAppDomain)
+            {
+                _appDomainAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            }
+            _newAssemblyAddedToAppDomain = false;
+            Assembly result = null;
+            lock (this)
+            {
+                // 1. 在临时文件夹中搜索程序集所对应的文件：对应于引用时 Copy Local 设置为 true 的程序集
+                var wantedDll = args.Name;
+                string dllPath = SearchAssemblyFileInDllFolders(wantedDll);
+                if (File.Exists(dllPath))
+                {
+                    result = this.LoadAddin(dllPath);
+                }
+                else // 2. 
+                {
+                    // wantedDll 可能有两种格式：
+                    // 1. eZcad.resources, Version = 1.0.0.0, Culture = zh - CN, PublicKeyToken = null
+                    // 2. eZstd, Version = 2.0.0.0, Culture = neutral, PublicKeyToken = null
+                    string[] array = wantedDll.Split(',');
+                    string dllNm = array[0];
+                    if (array.Length > 1)
+                    {
+                        string cult = array[2];
+                        var dllName = dllNm.Substring(0, dllNm.Length - ".resources".Length);
+                        if (dllNm.EndsWith(".resources", StringComparison.CurrentCultureIgnoreCase) &&
+                            !cult.EndsWith("neutral", StringComparison.CurrentCultureIgnoreCase)) // neutral 表示已经加载了的程序集
+                        {
+                            // 从当前程序域中已经加载了的程序集中去进行匹配
+                            foreach (var ass in _appDomainAssemblies)
+                            {
+                                var array2 = ass.FullName.Split(',');
+                                // 1. 首先进行基本的程序集名称的匹配
+                                if (array2[0] == dllName)
+                                {
+                                    // 2. 比较版本号 与 强命名
+                                    if (array2[1] == array[1] && array2[3] == array[3])
+                                    {
+                                        return ass;
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // 从当前程序域中已经加载了的程序集中去进行匹配
+                            var res = _appDomainAssemblies.FirstOrDefault(r => r.FullName == wantedDll);
+                            if (res != null)
+                            {
+                                return res;
+                            }
+                        }
+                        dllPath = this.SearchAssemblyFileInDllFolders(dllName);
+                        if (File.Exists(dllPath))
+                        {
+                            result = this.LoadAddin(dllPath);
+                            return result;
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        /// <summary> 源程序集的绝对路径 </summary>
+        /// <param name="srcDllPath"></param>
+        /// <param name="assemName"></param>
+        /// <returns></returns>
+        private string SearchAssemblyFileInDllFolders(string assemName)
+        {
+            string res;
+            res = Path.Combine(_srcDir, assemName);
+            if (File.Exists(res))
+            {
+                return res;
+            }
+            string[] array = new string[]
+            {
+                ".dll",
+                ".exe"
+            };
+            foreach (var ext in array)
+            {
+                res = Path.Combine(_srcDir, assemName + ext);
+                if (File.Exists(res))
+                {
+                    return res;
+                }
+            }
+            return res;
+        }
+        #endregion
+
+
+        /// <summary> 将程序集加载到程序中 </summary>
+        /// <param name="filePath">程序集的文件路径</param>
+        /// <returns></returns>
+        private Assembly LoadAddin(string filePath)
+        {
+            Assembly result = null;
+            try
+            {
+                Monitor.Enter(this);
+
+                // 方法一：Revit中的实现方法
+                result = Assembly.LoadFile(filePath); // LoadFile方法不会加载此程序集引用的其他程序集，也就是不会加载程序的依赖项。
+                if (result != null)
+                {
+                    _newAssemblyAddedToAppDomain = true;
+                }
+                // 方法二：zengfy 的实现方法，实验中证明不能替换上面的方法一
+                // byte[] buff = File.ReadAllBytes(filePath);  //先将插件拷贝到内存缓冲。一般情况下，当加载的文件大小大于2^32 byte (即4.2 GB），就会出现OutOfMemoryException，在实际测试中的极限值为630MB。
+                // result = Assembly.Load(buff); //不能直接通过LoadFrom或者LoadFile，而必须先将插件拷贝到内存，然后再从内存中Load
+
+                // MessageBox.Show(result.FullName);
+            }
+            finally
+            {
+                Monitor.Exit(this);
+            }
+            return result;
+        }
+
+    }
+}

--- a/eZcad_AddinManager/DocumentModifier.cs
+++ b/eZcad_AddinManager/DocumentModifier.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Windows;
 using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.EditorInput;
@@ -12,7 +13,7 @@ namespace eZcad
     internal class DocumentModifier : IDisposable
     {
         #region ---   执行外部命令
-        
+
         public delegate void ExternalCommand(DocumentModifier docMdf, SelectionSet impliedSelection);
 
         /// <summary> 执行外部命令，并且在执行命令之前，自动将 事务打开</summary>
@@ -32,6 +33,7 @@ namespace eZcad
                 {
                     docMdf.acTransaction.Abort(); // Abort the transaction and rollback to the previous state
                     string errorMessage = ex.Message + "\r\n\r\n" + ex.StackTrace;
+                    MessageBox.Show(errorMessage, "出错", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
             }
         }
@@ -179,6 +181,17 @@ namespace eZcad
             }
         }
 
+        #endregion
+
+        #region --- Other Utilities
+
+        /// <summary> 将 各种无关提示进行换行 ，使命令行中显示更清爽 </summary>
+        public static void LineFeedInCommandLine()
+        {
+            // 将加载命令后的各种无关提示进行换行
+            var ed = Application.DocumentManager.MdiActiveDocument.Editor;
+            ed.WriteMessage("\n \n");
+        }
         #endregion
     }
 }

--- a/eZcad_AddinManager/ExternalCommand/ExCommandFinder.cs
+++ b/eZcad_AddinManager/ExternalCommand/ExCommandFinder.cs
@@ -3,8 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Windows;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.EditorInput;
+using eZcad.AssemblyLoader;
+using Application = Autodesk.AutoCAD.ApplicationServices.Application;
 
 namespace eZcad.AddinManager
 {
@@ -16,49 +20,59 @@ namespace eZcad.AddinManager
         /// <returns></returns>
         public static List<ICADExCommand> RetriveExternalCommandsFromAssembly(string assemblyPath)
         {
-            Assembly asm;
-            // 方法一：zengfy 设计，在测试中通过。其关键在于不能直接将源程序集加载到进程中，
-            // 因为如果这样的话，在Visual Studio中修改此程序集的代码后不能重新编译，或者即使可以重新编译，在AddinManager加载的过程中也不会将其刷新。
-            byte[] buff = File.ReadAllBytes(assemblyPath);
-            //先将插件拷贝到内存缓冲。一般情况下，当加载的文件大小大于2^32 byte (即4.2 GB），就会出现OutOfMemoryException，在实际测试中的极限值为630MB。
-            asm = Assembly.Load(buff); //不能直接通过LoadFrom或者LoadFile，而必须先将插件拷贝到内存，然后再从内存中Load
-
-
-            // 方法二：通过LoadFile加载，在测试中发现如果这样做，则在 eZcad_AddinManager 调试过程中，如果在Visual Studio中修改了代码，则不能重新进行编译。
-            //asm = Assembly.LoadFile(assemblyPath);
-
-            return GetExternalCommandClass(asm);
-        }
-
-        private static List<ICADExCommand> GetExternalCommandClass(Assembly ass)
-        {
-            List<ICADExCommand> ecClasses = new List<ICADExCommand>();
+            var assemLoader = new eZAssemblyLoader(assemblyPath);
+            Assembly asm = null;
             Type[] classes = null;
-            // 加载程序集中的类型，以寻找对应的 Execute 方法。
             try
             {
-                classes = ass.GetTypes();
+                assemLoader.HookAssemblyResolve();
+                {
+                    // 方法一：zengfy 设计，在测试中通过。其关键在于不能直接将源程序集加载到进程中，
+                    // 因为如果这样的话，在Visual Studio中修改此程序集的代码后不能重新编译，或者即使可以重新编译，在AddinManager加载的过程中也不会将其刷新。
+                    byte[] buff = File.ReadAllBytes(assemblyPath);
+                    //先将插件拷贝到内存缓冲。一般情况下，当加载的文件大小大于2^32 byte (即4.2 GB），就会出现OutOfMemoryException，在实际测试中的极限值为630MB。
+                    asm = Assembly.Load(buff); //不能直接通过LoadFrom或者LoadFile，而必须先将插件拷贝到内存，然后再从内存中Load
+
+                    // 方法二：通过LoadFile加载，在测试中发现如果这样做，则在 eZcad_AddinManager 调试过程中，如果在Visual Studio中修改了代码，则不能重新进行编译。
+                    // asm = Assembly.LoadFile(assemblyPath);  // LoadFile方法不会加载此程序集引用的其他程序集，也就是不会加载程序的依赖项。
+                }
+
+                // 加载程序集中的类型，以寻找对应的 Execute 方法。
+
+                classes = asm.GetTypes();
             }
             catch (ReflectionTypeLoadException ex)
             {
                 // 有可能会出现找不到文件或程序集 eZstd 或其依赖项的报错。
                 classes = ex.Types;
             }
-
-            if (classes != null)
+            catch (Exception ex)
             {
+                // ignored
+                // MessageBox.Show(ex.Message, "加载程序集时出错了", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally
+            {
+                assemLoader.UnhookAssemblyResolve();
+            }
+            DocumentModifier.LineFeedInCommandLine();
+            return GetExternalCommandClass(asm, classes);
+        }
+
+        private static List<ICADExCommand> GetExternalCommandClass(Assembly ass, Type[] classes)
+        {
+
+            if (ass != null && classes != null && classes.Length > 0)
+            {
+                List<ICADExCommand> ecClasses = new List<ICADExCommand>();
                 foreach (Type cls in classes)
                 {
                     if ((cls != null) && cls.GetInterfaces().Any(r => r == typeof(ICADExCommand)))
                     // 说明这个类实现了 CAD 的命令接口
                     {
-                        // 寻找此类中所实现的那个 Execute 方法
-                        Type[] paraTypes = new Type[]
-                        {typeof(SelectionSet), typeof (string).MakeByRefType(), typeof (IList<ObjectId>).MakeByRefType()};
+                        MethodInfo m = FindExCommandMethod(cls);
                         //
-                        MethodInfo m = cls.GetMethod("Execute", paraTypes);
-                        //
-                        if (m != null && m.IsPublic)
+                        if (m != null)
                         {
                             // 生成一个实例并转换为接口
                             var ins = ass.CreateInstance(cls.FullName);
@@ -71,8 +85,32 @@ namespace eZcad.AddinManager
                         }
                     }
                 }
+                return ecClasses;
             }
-            return ecClasses;
+            return new List<ICADExCommand>();
+        }
+
+        /// <summary>
+        /// 从一个 实现了 CAD 的命令接口 的类中搜索到对应的 外部命令
+        /// </summary>
+        /// <param name="implimentedType">此类必须 实现了 CAD 的命令接口 </param>
+        /// <returns></returns>
+        public static MethodInfo FindExCommandMethod(Type implimentedType)
+        {
+            // 寻找此类中所实现的那个 Execute 方法
+            Type[] paraTypes = new Type[]
+            {
+                                typeof (SelectionSet), typeof (string).MakeByRefType(),
+                                typeof (IList<ObjectId>).MakeByRefType()
+            };
+            //
+            MethodInfo m = implimentedType.GetMethod("Execute", paraTypes);
+            //
+            if (m != null && m.IsPublic)
+            {
+                return m;
+            }
+            return null;
         }
     }
 }

--- a/eZcad_AddinManager/Properties/AssemblyInfo.cs
+++ b/eZcad_AddinManager/Properties/AssemblyInfo.cs
@@ -27,8 +27,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
 
 // In order to sign your assembly you must specify a key to use. Refer to the 
 // Microsoft .NET Framework documentation for more information on assembly signing.

--- a/eZcad_AddinManager/cmd_AddinManagerLoader.cs
+++ b/eZcad_AddinManager/cmd_AddinManagerLoader.cs
@@ -51,7 +51,7 @@ namespace eZcad_AddinManager
             // 先清空以前已经选择的对象集合
             SetImpliedSelection();
             Application.ShowModelessDialog(null, frm);
-            // Application.ShowModalDialog(frm);
+            //Application.ShowModalDialog(frm);
         }
 
         // Modal Command with localized name
@@ -83,5 +83,6 @@ namespace eZcad_AddinManager
                 ExCommandExecutor.ImpliedSelection = null;
             }
         }
+
     }
 }

--- a/eZcad_AddinManager/eZcad_AddinManager.csproj
+++ b/eZcad_AddinManager/eZcad_AddinManager.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>eZcad</RootNamespace>
     <AssemblyName>eZcad_AddinManager</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <FileUpgradeFlags>
@@ -33,6 +33,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,6 +46,7 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>..\bin\eZcad_AddinManager.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,16 +56,18 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DocumentationFile>bin\Debug\eZcad_AddinManager.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\eZcad_AddinManager.XML</DocumentationFile>
     <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -72,6 +77,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <!--ACA References Begin-->
@@ -79,16 +85,13 @@
     <!--AME Referebces Begin-->
     <!--AME Reference End-->
     <Reference Include="accoremgd">
-      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2014\accoremgd.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2016\accoremgd.dll</HintPath>
     </Reference>
     <Reference Include="acdbmgd">
-      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2014\acdbmgd.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2016\acdbmgd.dll</HintPath>
     </Reference>
     <Reference Include="acmgd">
-      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2014\acmgd.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>C:\Softwares\Civil Engineering\AutoCAD 2016\acmgd.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -122,7 +125,9 @@
       <DependentUpon>form_AddinManager.cs</DependentUpon>
     </Compile>
     <Compile Include="Addins\AutoSwitchIME.cs" />
+    <Compile Include="Addins\Class1.cs" />
     <Compile Include="Addins\EcLoadTemplate1.cs" />
+    <Compile Include="Addins\CmdDuplicatesFinder.cs" />
     <Compile Include="AssemblyInfo\AddinManagerAssembly.cs" />
     <Compile Include="AssemblyInfo\AssemblyInfoDllManager.cs" />
     <Compile Include="AssemblyInfo\AssemblyInfoFileManager.cs" />
@@ -134,6 +139,7 @@
     <Compile Include="AssemblyLoader\AssemblySelectorForm.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="AssemblyLoader\eZAssemblyLoader.cs" />
     <Compile Include="AssemblyLoader\FileUtils.cs" />
     <Compile Include="cmd_AddinManagerLoader.cs" />
     <Compile Include="DocumentModifier.cs" />


### PR DESCRIPTION
1. 与AutoCAD 2014不同，在AutoCAD 2016中，通过 AddinManager 将程序集中的外部命令加载到窗口中时，总是会出现“未能加载文件或程序集“***”或它的某一个依赖项”的报错。经历了几天的思考与测试，最终在 AddinManager 中设计了 eZcad.AssemblyLoader.eZAssemblyLoader 类，通过 在 AppDomain.CurrentDomain.AssemblyResolve 事件中返回当前程序域中的对应缺失程序集的思路，解决了此问题。
2. 设计了 eZcad.Utility.EntityArray2D<T> where T : Entity 类，用来将AutoCAD界面中的可见实体进行二维划分，即将多个实体分配到一个二维方格数组中。
3. 后面要进行将单行文字按中英文进行分割，并设置不同的字高的操作。